### PR TITLE
fix: use ${{ runner.temp }} instead of $HOME

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The secret will be [masked to prevent accidental exposure in logs](https://docs.
 ## `kubeconfig-location`
 
 **Optional** Specify a location the GitHub action should be saved to in the container while running the action. This is only necessary if you have configured the `kubeconfig` parameter in your project.garden.yaml provider configuration. Please note that the home directory in the GitHub action context is `/github/home`.
-Defaults to `/github/home/.kube/config`
+Defaults to `${{ runner.temp }}/garden/kubeconfig`
 
 ## `garden-version`
 
@@ -100,7 +100,7 @@ jobs:
           role-duration-seconds: 3600
       - uses: actions/checkout@v3.0.2
       - name: Deploy preview env with Garden
-        uses: garden-io/garden-action@v1.0
+        uses: garden-io/garden-action@v1.1
         with:
           command: deploy --env preview
           kubeconfig: ${{ secrets.KUBECONFIG }}
@@ -117,7 +117,7 @@ jobs:
           role-duration-seconds: 3600
       - uses: actions/checkout@v3.0.2
       - name: Run tests in ci environment with Garden
-        uses: garden-io/garden-action@v1.0
+        uses: garden-io/garden-action@v1.1
         with:
           command: >
             test --env ci

--- a/action.yaml
+++ b/action.yaml
@@ -25,7 +25,7 @@ inputs:
   kubeconfig-location:
     description: 'Path where Garden expects the kubeconfig. Defaults to $HOME/kube/config.'
     required: false
-    default: ~/.kube/config
+    default: ${{ runner.temp }}/garden/kubeconfig
   garden-version:
     description: 'Garden version. Defaults to latest stable.'
     required: false
@@ -75,10 +75,11 @@ runs:
       env:
         garden_version: ${{ inputs.garden-version }}
         GH_TOKEN: ${{ inputs.github-token }}
+        GARDEN_DIR: ${{ runner.temp }}/garden
       run: |
         # Install Garden
-        mkdir -p "$HOME/.garden"
-        cd "$HOME/.garden"
+        mkdir -p "$GARDEN_DIR"
+        cd "$GARDEN_DIR"
 
         if ! [ -d "$garden_version" ]; then
           echo "Downloading ${garden_version}..."
@@ -89,6 +90,7 @@ runs:
             tag_param="$garden_version"
           fi
 
+          # TODO: Consider using download.garden.io
           gh release download "$tag_param" --pattern '*-linux-amd64.tar.gz' -R garden-io/garden
           gh release download "$tag_param" --pattern '*-linux-amd64.tar.gz.sha256' -R garden-io/garden
           checksum=$(openssl dgst -sha256 *-linux-amd64.tar.gz | awk '{ print $2 }')
@@ -107,7 +109,7 @@ runs:
         ln -sfn "$garden_version" bin
 
         echo "Using garden version $(bin/garden --version)"
-        echo "${HOME}/.garden/bin" >> "$GITHUB_PATH"
+        echo "$GARDEN_DIR/bin" >> "$GITHUB_PATH"
     - name: run garden
       if: inputs.command
       shell: bash


### PR DESCRIPTION
We change the location to store garden-action temporary files to use ${{ runner.temp }}. This directory is being cleaned before and after the job execution. 

This is helpful in case this action is being used on self-hosted runners, and stops polluting the home directory of self hosted runners in case the job is not being executed in isolated VMs.

