### PR TITLE
chore: update edge tag name

### DIFF
--- a/.github/workflows/test-garden.yaml
+++ b/.github/workflows/test-garden.yaml
@@ -25,10 +25,10 @@ jobs:
       # Simple test cases for the action code.
       # This is basically a smoke test; Semantic behaviour to be checked manually
 
-      - name: Test 1 - Version should be edge
+      - name: Test 1 - Version should be edge-bonsai
         uses: ./
         with:
-          garden-version: edge
+          garden-version: edge-bonsai
           command: --version
 
       - name: Test 2 - Version should be latest


### PR DESCRIPTION
The edge tag does not exist anymore, only edge-acorn and edge-bonsai. Update the test