### PR TITLE
fix: display garden version correctly

### DIFF
--- a/.github/workflows/test-garden.yaml
+++ b/.github/workflows/test-garden.yaml
@@ -28,13 +28,13 @@ jobs:
       - name: Test 1 - Version should be edge
         uses: ./
         with:
-          garden-version: edge
-          command: --version
+          garden-version: edge-bonsai
+          command: version
 
       - name: Test 2 - Version should be latest
         uses: ./
         with:
-          command: --version
+          command: version
 
       - name: Test 3 – Only prepare garden version
         uses: ./
@@ -42,7 +42,7 @@ jobs:
           garden-version: 0.12.44
 
       - name: Test 4 - Version should be 0.12.44
-        run: garden --version
+        run: garden version
 
       - name: Test 5 – Prepare kubeconfig and garden-auth-token
         uses: ./

--- a/action.yaml
+++ b/action.yaml
@@ -108,7 +108,7 @@ runs:
         # Create new symlink, or overwrite existing
         ln -sfn "$garden_version" bin
 
-        echo "Using garden version $(bin/garden version)"
+        echo "Using $(bin/garden version)"
         echo "$GARDEN_DIR/bin" >> "$GITHUB_PATH"
     - name: run garden
       if: inputs.command

--- a/action.yaml
+++ b/action.yaml
@@ -108,7 +108,7 @@ runs:
         # Create new symlink, or overwrite existing
         ln -sfn "$garden_version" bin
 
-        echo "Using garden version $(bin/garden --version)"
+        echo "Using garden version $(bin/garden version)"
         echo "$GARDEN_DIR/bin" >> "$GITHUB_PATH"
     - name: run garden
       if: inputs.command


### PR DESCRIPTION
Currently the action prints the output of "garden version" when using Garden 0.13 at the beginning, instead of the version.

In 0.13 we removed the `-v/--version` flag and now it can only be queried using `garden version`.
 
This also works for Garden 0.12.